### PR TITLE
Check UDIO response length

### DIFF
--- a/communication/command/crypto.go
+++ b/communication/command/crypto.go
@@ -73,6 +73,15 @@ func DecryptCommand(encryptedCmd Command, privateKey []byte, nukiPubKey []byte) 
 	return binary.LittleEndian.Uint32(decrypted[:4]), decrypted[4:]
 }
 
+func IsCommandComplete(encryptedCmd Command) bool {
+	length := len(encryptedCmd)
+	if length < 30 {
+		return false
+	}
+	expectedLength := 30 + binary.LittleEndian.Uint16(encryptedCmd[28:30])
+	return length == int(expectedLength)
+}
+
 // only for monkey patching purposes
 var newNonce192 = func() []byte {
 	nonce := new([24]byte)

--- a/communication/user_specific_data_io.go
+++ b/communication/user_specific_data_io.go
@@ -86,7 +86,7 @@ func (u *udioCommunicator) receive(payload []byte) {
 
 	u.curEncryptedCommand = append(u.curEncryptedCommand, payload...)
 
-	if len(payload) == mtu {
+	if !command.IsCommandComplete(u.curEncryptedCommand) {
 		//we expect more data
 		return
 	}


### PR DESCRIPTION
The "read states" response on my Smart Lock 3.0 has 80 bytes and is sent
as 4 packets with 20 bytes each - exactly the MTU. It never got through
(resulting in a timeout) because the previous code was waiting for a
less-than-MTU-sized packet before trying to decrypt it.

With this change the packet length encoded in the encrypted command is
used to check whether the response received so far is complete.