### PR TITLE
Interpret PIN as decimal string (fixes #6)

### DIFF
--- a/communication/command/pin.go
+++ b/communication/command/pin.go
@@ -2,8 +2,8 @@ package command
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
+	"strconv"
 )
 
 // InvalidPinError will be returned if the given pin is invalid
@@ -12,15 +12,15 @@ var InvalidPinError = fmt.Errorf("the given pin is invalid")
 type Pin uint16
 
 func NewPin(pin string) (Pin, error) {
-	if len(pin) != 4 || hex.DecodedLen(len(pin)) != 2 {
+	if len(pin) != 4 {
 		return 0, InvalidPinError
 	}
-	rawPin, err := hex.DecodeString(pin)
+	rawPin, err := strconv.ParseUint(pin, 10, 16)
 	if err != nil {
 		return 0, InvalidPinError
 	}
 
-	return Pin(binary.BigEndian.Uint16(rawPin)), nil
+	return Pin(rawPin), nil
 }
 
 func (p Pin) AsByte() []byte {


### PR DESCRIPTION
Previously it was expected as hex string, but if a script asks a user to enter their PIN, "1234" is probably more natural to type than "04D2".